### PR TITLE
FIX: cookie parrsing error fixed, etc...

### DIFF
--- a/src/Request/RequestHandler.cpp
+++ b/src/Request/RequestHandler.cpp
@@ -48,7 +48,8 @@ t_error ConvertUri(std::string rq_uri,
     const std::string& query = rq_uri.substr(query_index + 1);
     http.entity_length_ = query.length();
     http.temp_entity_.reserve(http.entity_length_);
-    http.temp_entity_.insert(http.temp_entity_.end(), query.begin(), query.end());
+    http.temp_entity_.insert(http.temp_entity_.end(), query.begin(),
+                             query.end());
     http.entity_ = http.temp_entity_.begin().base();
     rq_uri = rq_uri.substr(0, query_index);
   }
@@ -85,9 +86,9 @@ inline void SetPrevCookie(s_client_type* client_type, t_http* http) {
 
   /* 발급 받은 Cookie가 없을 경우. (예: Cookie: id=) */
   if (equal_pos + 1 == cookie_line.size()) return;
-
+  size_t semicolon_pos = cookie_line.find(";");
   std::string prev_id =
-      cookie_line.substr(equal_pos + 1, cookie_line.size() - equal_pos + 1);
+      cookie_line.substr(equal_pos + 1, semicolon_pos - equal_pos - 1);
   int timer = atoi(client_type->GetConfig().main_config_.at(TIMEOUT).c_str());
   if (timer != 0) {
     ServerConfig::ChangeEvents(client_type->GetFD(), EVFILT_TIMER, EV_CLEAR,

--- a/src/Server/ServerInit.cpp
+++ b/src/Server/ServerInit.cpp
@@ -80,12 +80,6 @@ void ServerKinit(ServerConfig& config) {
     s_server_type* udata = new s_server_type(config, i, server_socket[i]);
     ServerConfig::ChangeEvents(server_socket[i], EVFILT_READ,
                                EV_ADD | EV_ENABLE, 0, 0, udata);
-    // std::cout << "[ Server(" << GREEN << std::setw(10) << std::right
-    //           << config.GetServerList(i).main_config_.at("server_name") <<
-    //           RESET
-    //           << ") : " << std::setw(30) << std::right << "Port is activated
-    //           ]"
-    //           << std::endl;
   }
   return;
 }
@@ -119,8 +113,6 @@ void ServerRun(ServerConfig& config) {
         case WORK: {
           s_work_type* work_type = static_cast<s_work_type*>(ft_filter);
           if (work_type->GetWorkType() == file) {
-            // std::cout << "FILE steps"
-            //           << " / Task FD : " << ft_filter->GetFD() << std::endl;
             if (work_type->GetClientStage() == GET_START)
               WorkGet(curr_event);
             else if (work_type->GetClientStage() == POST_START) {
@@ -128,16 +120,11 @@ void ServerRun(ServerConfig& config) {
             }
           } else if (work_type->GetWorkType() == cgi)
             WorkCGIPost(curr_event);
-          // std::cout << "cgi steps" << std::endl;
         } break;
         case CLIENT: {
           if (curr_event->filter == EVFILT_READ) {
             {
-              //   std::cout << "READ steps"
-              //             << " / Task FD : " << ft_filter->GetFD() <<
-              //             std::endl;
               if (curr_event->data == 0) {
-                //     std::cout << "no data" << std::endl;
                 continue;
               } else {
                 static_cast<s_client_type*>(ft_filter)->GetTimeData()[0] =
@@ -153,14 +140,6 @@ void ServerRun(ServerConfig& config) {
                   break;
                 }
                 case POST_READY: {
-                  // if (static_cast<s_work_type*>(ft_filter)->GetWorkType()
-                  // ==
-                  //     file)
-                  //     {
-                  //       ClientFilePost(curr_event);
-                  //     }
-                  // else
-                  //   ClientCGIPost(curr_event);
                   ClientFilePost(curr_event);
                   break;
                 }
@@ -178,9 +157,6 @@ void ServerRun(ServerConfig& config) {
             }
           } else if (curr_event->filter == EVFILT_WRITE) {
             s_client_type* client = static_cast<s_client_type*>(ft_filter);
-            // std::cout << "WRITE steps"
-            //           << " / Task FD : " << ft_filter->GetFD() <<
-            // std::endl;
             t_send* send = &client->GetSend();
             switch (send->flags) {
               case 0:  // Make header(header + body)
@@ -197,45 +173,28 @@ void ServerRun(ServerConfig& config) {
               default:
                 SendFin(curr_event, client);
             }
-            /*if (client->GetStage() == RES_SEND) {
-              SendProcess(curr_event, client);
-            } else {
-              char* msg_top = strdup("");
-              char* send_msg = strdup("");
-              if (client->IsChunked()) {
-                send_msg = MakeSendMessage(client, msg_top);
-              } else {
-                client->SetResponse();
-                msg_top = MaketopMessage(client);
-                send_msg = MakeSendMessage(client, msg_top);
-              }
-              delete msg_top;
-              client->SetBuf(send_msg);
-              SendMessageLength(client);
-              SendProcess(curr_event, client);
-              if (client->GetStage() == RES_SEND) continue;
-              SendFin(curr_event, client);
-            }*/
           } else if (curr_event->filter == EVFILT_TIMER ||
                      curr_event->flags & EV_EOF) {
-            DeleteUdata(ft_filter);
+            s_client_type* client =
+                static_cast<s_client_type*>(curr_event->udata);
+            if (client->GetStage() != DEF || client->GetStage() != END) {
+              int timer = atoi(client->GetConfig()
+                                   .main_config_.find("timeout")
+                                   ->second.c_str());
+              ServerConfig::ChangeEvents(client->GetFD(), EVFILT_TIMER, EV_ADD,
+                                         NOTE_SECONDS, timer, client);
+            } else {
+              DeleteUdata(ft_filter);
+            }
           }
         } break;
         case LOGGER: {
           if (curr_event->filter == EVFILT_WRITE) {
-            // std::cout << "Logger steps"
-            //           << " / Task FD : "
-            //           <<
-            //           static_cast<s_logger_type*>(curr_event->udata)->GetFD()
-            //           << std::endl;
             static_cast<s_logger_type*>(ft_filter)->PushData();
           }
         } break;
         default: {  // Server case
           sockaddr_in* addr_info = config.GetServerAddress();
-          //   std::cout << "SERVER steps"
-          //             << " / Task FD : " << ft_filter->GetFD() <<
-          //             std::endl;
           socklen_t addrlen = sizeof(addr_info);
           int client_fd(accept(curr_event->ident,
                                reinterpret_cast<sockaddr*>(addr_info),

--- a/src/makePage/auto_index_page.cpp
+++ b/src/makePage/auto_index_page.cpp
@@ -33,7 +33,6 @@ void MakeAutoindexBody(s_client_type* client, t_http& response,
   if (dir != NULL) {
     ent = readdir(dir);
     while (ent != NULL) {
-      // std::cout << "ent->d_name : " << ent->d_name << std::endl;
       if (IsDirectory(ent)) {
         std::string location(client->GetLocationConfig().location_);
         std::string dot(".");


### PR DESCRIPTION
- cookie ID 가 잘못 들어오는 경우(여러개) 이 경우 ID 가 정상적으로 설정되지 않는 것을 발견 -> request handling 에서 substr 하는 로직 추가함. 
- EVFILT_TIMER 가 짧아 작업 도중에 종료되는 것을 막고자, 중간 단계에서 EVFILT_TIMER 가 발생시 이를 초기화하는 작업을 넣어둠